### PR TITLE
Updated URLs to vipps.no due to new vipps.no site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains developer resources for the Vipps eCommerce API.
 For more information about this product, please see
-[Vipps på Nett](https://www.vipps.no/bedrift/vipps-pa-nett).
+[Vipps på Nett](https://www.vipps.no/produkter-og-tjenester/bedrift/ta-betalt-paa-nett/ta-betalt-paa-nett/).
 
 [Getting Started](https://github.com/vippsas/vipps-developers/blob/master/vipps-getting-started.md): information about API keys, product activation, etc please see the guide.
 

--- a/vipps-ecom-api-checklist.md
+++ b/vipps-ecom-api-checklist.md
@@ -4,7 +4,7 @@ Document version 0.1.0
 
 # Overall flow for direct integrations
 
-1. The merchant orders [Vipps på Nett](https://www.vipps.no/bedrift/vipps-pa-nett)
+1. The merchant orders [Vipps på Nett](https://www.vipps.no/produkter-og-tjenester/bedrift/ta-betalt-paa-nett/ta-betalt-paa-nett/)
 2. Vipps completes customer control (KYC, PEP, AML, etc)
 3. The merchant received login credentials for retrieving API keys
 4. The merchant completes the direct integration with the [Vipps eCommerce API](https://github.com/vippsas/vipps-ecom-api)

--- a/vipps-ecom-api-faq.md
+++ b/vipps-ecom-api-faq.md
@@ -45,8 +45,8 @@ We are continuously improving the error messages in the Vipps app. Please note t
 # Can I use my "Vipps-nummer" in my webshop?
 
 No. According to Norwegian law you must be able to offer refunds.
-This is not supported with [Vipps-nummer](https://www.vipps.no/bedrift/vippsnummer).
-You need [Vipps på Nett](https://www.vipps.no/bedrift/vipps-pa-nett).
+This is not supported with [Vipps-nummer](https://www.vipps.no/produkter-og-tjenester/bedrift/ta-betalt-i-butikk/ta-betalt-med-vipps/).
+You need [Vipps på Nett](https://www.vipps.no/produkter-og-tjenester/bedrift/ta-betalt-paa-nett/ta-betalt-paa-nett/).
 
 # Why does capture fail?
 
@@ -65,7 +65,7 @@ to the customer's server. If this server is slow,
 or has a slow internet connection, the delay may cause Vipps Hurtigkasse to fail due to a timeout.
 The solution to this is a faster server and internet connection.
 
-Information for [Vipps for WooCommerce](https://www.vipps.no/bedrift/vipps-pa-nett/woocommerce):
+Information for [Vipps for WooCommerce](https://www.vipps.no/produkter-og-tjenester/bedrift/ta-betalt-paa-nett/ta-betalt-paa-nett/woocommerce/):
 Some third party plugins do not work with Vipps Hurtigkasse. Please ask for help in the
 [support forum](https://wordpress.org/support/plugin/woo-vipps),
 and include information about the plugins you have installed.
@@ -136,7 +136,6 @@ The settlement flow is as follows:
 
 See also [Settlements](https://github.com/vippsas/vipps-developers/tree/master/settlements).
 
-See https://www.vipps.no/sporsmal for more details.
 
 # How long does it take from a refund is made until the money is in the customer's account?
 

--- a/vipps-ecom-api.md
+++ b/vipps-ecom-api.md
@@ -133,9 +133,7 @@ and to complete the payment in a familiar way.
 
 ### Express checkout payments
 
-These are payments related to
-[Vipps Hurtigkasse](https://www.vipps.no/bedrift/vipps-pa-nett/hurtigkasse),
-where Vipps reduces the typical purchase process to a few simple steps:
+These are payments related to Vipps Hurtigkasse, where Vipps reduces the typical purchase process to a few simple steps:
 
 1. The user clicks on the "Vipps Hurtigkasse" button
 2. The user confirms the amount, delivery address and delivery method in the Vipps app


### PR DESCRIPTION
* Info about "hurtigkasse" is no longer on a single page as far as I could find, so removed the link.
* Also link to /sporsmal is now /help, but does not contain an answer to the question referenced.