### PR TITLE
Changed errorCode to type string

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "description": "# Vipps eCommerce API\nAdditional API documentation: https://github.com/vippsas/vipps-ecom-api/\n",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "title": "Vipps eCommerce API"
   },
   "tags": [
@@ -1162,8 +1162,8 @@
         "type": "object",
         "properties": {
           "errorCode": {
-            "type": "integer",
-            "example": 45,
+            "type": "string",
+            "example": "45",
             "description": "The number code for the error."
           },
           "errorGroup": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,7 +3,7 @@ info:
   description: |
     # Vipps eCommerce API
     Additional API documentation: https://github.com/vippsas/vipps-ecom-api/
-  version: 1.0.13
+  version: 1.0.14
   title: Vipps eCommerce API
 tags:
   - name: Authorization Service
@@ -936,8 +936,8 @@ components:
       type: object
       properties:
         errorCode:
-          type: integer
-          example: 45
+          type: string
+          example: '45'
           description: The number code for the error.
         errorGroup:
           type: string


### PR DESCRIPTION
As that is what we actually send, not "integer" as it's stated now.
Got this from an integrator: 
"errorInfo":{"errorCode":"45", (...) }