### PR TITLE
Added Error object to all errors

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "description": "# Vipps eCommerce API\nAdditional API documentation: https://github.com/vippsas/vipps-ecom-api/\n",
-    "version": "1.0.23",
+    "version": "1.1.0",
     "title": "Vipps eCommerce API"
   },
   "tags": [
@@ -78,28 +78,84 @@
             }
           },
           "400": {
-            "description": "Bad request (Missing a required parameter or bad request format)"
+            "description": "Bad request (Missing a required parameter or bad request format)",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "402": {
-            "description": "Payment Failed"
+            "description": "Payment Failed",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Request Forbidden"
+            "description": "Request Forbidden",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource Not Found"
+            "description": "Resource Not Found",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "405": {
-            "description": "Request method not supported"
+            "description": "Request method not supported",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "415": {
-            "description": "Unsupported media type"
+            "description": "Unsupported media type",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "A server-side error"
+            "description": "A server-side error",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -389,28 +445,84 @@
             }
           },
           "400": {
-            "description": "Bad request (Missing a required parameter or bad request format)"
+            "description": "Bad request (Missing a required parameter or bad request format)",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "402": {
-            "description": "Payment Failed"
+            "description": "Payment Failed",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Request Forbidden"
+            "description": "Request Forbidden",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource Not Found"
+            "description": "Resource Not Found",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "405": {
-            "description": "Request method not supported"
+            "description": "Request method not supported",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "415": {
-            "description": "Unsupported media type"
+            "description": "Unsupported media type",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "A server-side error"
+            "description": "A server-side error",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -538,31 +650,94 @@
             }
           },
           "400": {
-            "description": "Bad request (Missing a required parameter or bad request format)"
+            "description": "Bad request (Missing a required parameter or bad request format)",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "402": {
-            "description": "Payment Failed"
+            "description": "Payment Failed",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Request Forbidden"
+            "description": "Request Forbidden",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource Not Found"
+            "description": "Resource Not Found",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "405": {
-            "description": "Request method not supported"
+            "description": "Request method not supported",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "415": {
-            "description": "Unsupported media type"
+            "description": "Unsupported media type",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "A server-side error"
+            "description": "A server-side error",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "503": {
-            "description": "Service Unavailable"
+            "description": "Service Unavailable",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -645,31 +820,94 @@
             }
           },
           "400": {
-            "description": "Bad request (Missing a required parameter or bad request format)"
+            "description": "Bad request (Missing a required parameter or bad request format)",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "402": {
-            "description": "Payment Failed"
+            "description": "Payment Failed",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Request Forbidden"
+            "description": "Request Forbidden",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource Not Found"
+            "description": "Resource Not Found",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "405": {
-            "description": "Request method not supported"
+            "description": "Request method not supported",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "415": {
-            "description": "Unsupported media type"
+            "description": "Unsupported media type",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "A server-side error"
+            "description": "A server-side error",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "503": {
-            "description": "Service Unavailable"
+            "description": "Service Unavailable",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -752,31 +990,94 @@
             }
           },
           "400": {
-            "description": "Bad request (Missing a required parameter or bad request format)"
+            "description": "Bad request (Missing a required parameter or bad request format)",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "402": {
-            "description": "Payment Failed"
+            "description": "Payment Failed",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Request Forbidden"
+            "description": "Request Forbidden",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource Not Found"
+            "description": "Resource Not Found",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "405": {
-            "description": "Request method not supported"
+            "description": "Request method not supported",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "415": {
-            "description": "Unsupported media type"
+            "description": "Unsupported media type",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "A server-side error"
+            "description": "A server-side error",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "503": {
-            "description": "Service Unavailable"
+            "description": "Service Unavailable",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -843,31 +1144,84 @@
             "description": "Force approve payment response"
           },
           "400": {
-            "description": "Bad request (Missing a required parameter or bad request format)"
+            "description": "Bad request (Missing a required parameter or bad request format)",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "402": {
-            "description": "Payment Failed"
+            "description": "Payment Failed",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Request Forbidden"
+            "description": "Request Forbidden",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource Not Found"
+            "description": "Resource Not Found",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "405": {
-            "description": "Request method not supported"
+            "description": "Request method not supported",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "415": {
-            "description": "Unsupported media type"
+            "description": "Unsupported media type",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "A server-side error"
-          },
-          "503": {
-            "description": "Service Unavailable"
+            "description": "A server-side error",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -939,31 +1293,94 @@
             }
           },
           "400": {
-            "description": "Bad request (Missing a required parameter or bad request format)"
+            "description": "Bad request (Missing a required parameter or bad request format)",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "402": {
-            "description": "Payment Failed"
+            "description": "Payment Failed",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Request Forbidden"
+            "description": "Request Forbidden",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource Not Found"
+            "description": "Resource Not Found",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "405": {
-            "description": "Request method not supported"
+            "description": "Request method not supported",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "415": {
-            "description": "Unsupported media type"
+            "description": "Unsupported media type",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "A server-side error"
+            "description": "A server-side error",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "503": {
-            "description": "Service Unavailable"
+            "description": "Service Unavailable",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -1018,28 +1435,84 @@
             }
           },
           "400": {
-            "description": "Bad request (Missing a required parameter or bad request format)"
+            "description": "Bad request (Missing a required parameter or bad request format)",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "402": {
-            "description": "Payment Failed"
+            "description": "Payment Failed",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Request Forbidden"
+            "description": "Request Forbidden",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource Not Found"
+            "description": "Resource Not Found",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "405": {
-            "description": "Request method not supported"
+            "description": "Request method not supported",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "415": {
-            "description": "Unsupported media type"
+            "description": "Unsupported media type",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "A server-side error"
+            "description": "A server-side error",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -1354,7 +1827,47 @@
           }
         }
       },
-      "CallbackTransactionInfoStatus": {
+      "CallbackTransactionInfoRegular": {
+        "type": "object",
+        "required": [
+          "amount",
+          "status",
+          "timeStamp"
+        ],
+        "properties": {
+          "amount": {
+            "type": "number",
+            "format": "double",
+            "description": "Ordered amount in øre",
+            "example": 20000
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "RESERVED",
+              "SALE",
+              "CANCELLED",
+              "REJECTED",
+              "AUTO_CANCEL",
+              "SALE_FAILED",
+              "RESERVE_FAILED"
+            ],
+            "description": "Status which gives the current state of the payment within Vipps. See the [API guide](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#callbacks) for more information.",
+            "example": "RESERVE"
+          },
+          "timeStamp": {
+            "type": "string",
+            "description": "Timestamp in ISO-8601 representing when the operation was performed.",
+            "example": "2018-12-12T11:18:38.246Z"
+          },
+          "transactionId": {
+            "type": "string",
+            "description": "Vipps transaction id",
+            "example": "5001420062"
+          }
+        }
+      },
+      "CallbackTransactionInfoExpress": {
         "type": "object",
         "required": [
           "amount",
@@ -1375,7 +1888,9 @@
               "SALE",
               "CANCELLED",
               "REJECTED",
-              "AUTO_CANCEL"
+              "AUTO_CANCEL",
+              "SALE_FAILED",
+              "RESERVE_FAILED"
             ],
             "description": "Status which gives the current state of the payment within Vipps. See the [API guide](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#callbacks) for more information.",
             "example": "RESERVE"
@@ -2032,7 +2547,7 @@
             "$ref": "#/components/schemas/ShippingDetailsRequest"
           },
           "transactionInfo": {
-            "$ref": "#/components/schemas/CallbackTransactionInfoStatus"
+            "$ref": "#/components/schemas/CallbackTransactionInfoExpress"
           },
           "userDetails": {
             "$ref": "#/components/schemas/UserDetails"
@@ -2066,7 +2581,7 @@
             "maxLength": 30
           },
           "transactionInfo": {
-            "$ref": "#/components/schemas/CallbackTransactionInfoStatus"
+            "$ref": "#/components/schemas/CallbackTransactionInfoRegular"
           },
           "errorInfo": {
             "$ref": "#/components/schemas/callbackErrorInfo"
@@ -2198,6 +2713,45 @@
             "$ref": "#/components/schemas/RegularCheckOutPaymentRequest"
           }
         ]
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "errorGroup",
+          "errorCode",
+          "errorMessage",
+          "contextId"
+        ],
+        "properties": {
+          "errorGroup": {
+            "type": "string",
+            "description": "The error group. See: https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#error-groups",
+            "enum": [
+              "Authentication",
+              "Payment",
+              "InvalidRequest",
+              "VippsError",
+              "User",
+              "Merchant"
+            ],
+            "example": "Payment"
+          },
+          "errorCode": {
+            "type": "string",
+            "description": "The error code. See: https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#error-codes",
+            "example": "44"
+          },
+          "errorMessage": {
+            "type": "string",
+            "description": "A description of what went wrong. See https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#errors",
+            "example": "Refused by issuer because of expired card"
+          },
+          "contextId": {
+            "type": "string",
+            "description": "A unique id for this error, useful for searching in logs",
+            "example": "f70b8bf7-c843-4bea-95d9-94725b19895f"
+          }
+        }
       }
     }
   }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,7 +3,7 @@ info:
   description: |
     # Vipps eCommerce API
     Additional API documentation: https://github.com/vippsas/vipps-ecom-api/
-  version: 1.0.23
+  version: 1.1.0
   title: Vipps eCommerce API
 tags:
   - name: Authorization Service
@@ -61,20 +61,52 @@ paths:
                 $ref: '#/components/schemas/AuthorizationTokenResponse'
         '400':
           description: Bad request (Missing a required parameter or bad request format)
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '402':
           description: Payment Failed
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '403':
           description: Request Forbidden
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Resource Not Found
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '405':
           description: Request method not supported
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '415':
           description: Unsupported media type
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: A server-side error
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
   '[consentRemovalPrefix]/v2/consents/{userId}':
     delete:
       tags:
@@ -337,20 +369,52 @@ paths:
                 $ref: '#/components/schemas/InitiatePaymentV2Representation'
         '400':
           description: Bad request (Missing a required parameter or bad request format)
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '402':
           description: Payment Failed
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '403':
           description: Request Forbidden
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Resource Not Found
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '405':
           description: Request method not supported
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '415':
           description: Unsupported media type
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: A server-side error
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
   '[callbackPrefix]/v2/payments/{orderId}':
     post:
       tags:
@@ -462,22 +526,58 @@ paths:
                 $ref: '#/components/schemas/TransactionResponseCapture'
         '400':
           description: Bad request (Missing a required parameter or bad request format)
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '402':
           description: Payment Failed
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '403':
           description: Request Forbidden
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Resource Not Found
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '405':
           description: Request method not supported
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '415':
           description: Unsupported media type
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: A server-side error
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '503':
           description: Service Unavailable
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
   '/ecomm/v2/payments/{orderId}/cancel':
     put:
       tags:
@@ -544,22 +644,58 @@ paths:
                 $ref: '#/components/schemas/TransactionResponseCancel'
         '400':
           description: Bad request (Missing a required parameter or bad request format)
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '402':
           description: Payment Failed
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '403':
           description: Request Forbidden
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Resource Not Found
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '405':
           description: Request method not supported
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '415':
           description: Unsupported media type
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: A server-side error
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '503':
           description: Service Unavailable
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
   '/ecomm/v2/payments/{orderId}/refund':
     post:
       tags:
@@ -633,22 +769,58 @@ paths:
                 $ref: '#/components/schemas/TransactionResponseRefund'
         '400':
           description: Bad request (Missing a required parameter or bad request format)
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '402':
           description: Payment Failed
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '403':
           description: Request Forbidden
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Resource Not Found
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '405':
           description: Request method not supported
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '415':
           description: Unsupported media type
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: A server-side error
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '503':
           description: Service Unavailable
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
   '/ecomm/v2/integration-test/payments/{orderId}/approve':
     post:
       tags:
@@ -704,20 +876,52 @@ paths:
           description: Force approve payment response
         '400':
           description: Bad request (Missing a required parameter or bad request format)
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '402':
           description: Payment Failed
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '403':
           description: Request Forbidden
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Resource Not Found
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '405':
           description: Request method not supported
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '415':
           description: Unsupported media type
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: A server-side error
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
   '/ecomm/v2/payments/{orderId}/details':
     get:
       tags:
@@ -774,22 +978,58 @@ paths:
                 $ref: '#/components/schemas/GetTransactionDetails'
         '400':
           description: Bad request (Missing a required parameter or bad request format)
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '402':
           description: Payment Failed
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '403':
           description: Request Forbidden
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Resource Not Found
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '405':
           description: Request method not supported
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '415':
           description: Unsupported media type
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: A server-side error
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '503':
           description: Service Unavailable
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
   '/ecomm/v2/payments/{orderId}/status':
     get:
       deprecated: true
@@ -832,20 +1072,52 @@ paths:
                 $ref: '#/components/schemas/GetPaymentStatusResponse'
         '400':
           description: Bad request (Missing a required parameter or bad request format)
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '402':
           description: Payment Failed
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '403':
           description: Request Forbidden
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Resource Not Found
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '405':
           description: Request method not supported
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '415':
           description: Unsupported media type
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: A server-side error
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   requestBodies:
     PaymentActionsRequest:
@@ -1890,3 +2162,34 @@ components:
       oneOf:
         - $ref: '#/components/schemas/ExpressCheckOutPaymentRequest'
         - $ref: '#/components/schemas/RegularCheckOutPaymentRequest'
+    Error:
+      type: object
+      required:
+        - errorGroup
+        - errorCode
+        - errorMessage
+        - contextId
+      properties:
+        errorGroup:
+          type: string
+          description: "The error group. See: https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#error-groups"
+          enum:
+            - Authentication
+            - Payment
+            - InvalidRequest
+            - VippsError
+            - User
+            - Merchant
+          example: "Payment"
+        errorCode:
+          type: string
+          description: "The error code. See: https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#error-codes"
+          example: "44"
+        errorMessage:
+          type: string
+          description: "A description of what went wrong. See https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#errors"
+          example: "Refused by issuer because of expired card"
+        contextId:
+          type: string
+          description: "A unique id for this error, useful for searching in logs"
+          example: f70b8bf7-c843-4bea-95d9-94725b19895f


### PR DESCRIPTION
Added `Error` object and referenced it in all error responses.

Since some errors are not from the API itself (some come from Azure), this is not 100 % correct yet, but it should be easy to add an `ErrorAzure` (or something) to specify the `HTTP 503 Gateway Timeout` errors, etc. 

This is the (current) `Error`:

```
    Error:
      type: object
      required:
        - errorGroup
        - errorCode
        - errorMessage
        - contextId
      properties:
        errorGroup:
          type: string
          description: "The error group. See: https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#error-groups"
          enum:
            - Authentication
            - Payment
            - InvalidRequest
            - VippsError
            - User
            - Merchant
          example: "Payment"
        errorCode:
          type: string
          description: "The error code. See: https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#error-codes"
          example: "44"
        errorMessage:
          type: string
          description: "A description of what went wrong. See https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#errors"
          example: "Refused by issuer because of expired card"
        contextId:
          type: string
          description: "A unique id for this error, useful for searching in logs"
          example: f70b8bf7-c843-4bea-95d9-94725b19895f
```