### PR TITLE
Optional Vipps HTTP headers

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -31,6 +31,7 @@ paths:
           schema:
             type: string
             format: guid
+          example: fb492b5e-7907-4d83-ba20-c7fb60ca35de
         - name: client_secret
           in: header
           description: >-
@@ -38,6 +39,7 @@ paths:
           required: true
           schema:
             type: string
+          example: Y8Kteew6GE2ZmeycEt6egg==
         - name: Ocp-Apim-Subscription-Key
           in: header
           description: >-
@@ -45,6 +47,7 @@ paths:
           required: true
           schema:
             type: string
+          example: 0f14ebcab0ec4b29ae0cb90d91b4a84a
       description: >-
         Authorization token API endpoint helps to get the JWT Bearer token that
         needs to be passed in every API request in the Authorization header. The

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,7 +3,7 @@ info:
   description: |
     # Vipps eCommerce API
     Additional API documentation: https://github.com/vippsas/vipps-ecom-api/
-  version: 1.3.1
+  version: 1.4.0
   title: Vipps eCommerce API
 tags:
   - name: Authorization Service
@@ -230,6 +230,30 @@ paths:
           required: false
           schema:
             type: string
+        - name: Vipps-System-Name
+          in: header
+          description: The name of the ecommerce solution
+          schema:
+            type: string
+          example: woocommerce
+        - name: Vipps-System-Version
+          in: header
+          description: The version number of the ecommerce solution
+          schema:
+            type: string
+          example: "5.4"
+        - name: Vipps-System-Plugin-Name
+          in: header
+          description: The name of the ecommerce plugin
+          schema:
+            type: string
+          example: "vipps-woocommerce"
+        - name: Vipps-System-Plugin-Version
+          in: header
+          description: The version number of the ecommerce plugin
+          schema:
+            type: string
+          example: "1.2.1"
       requestBody:
         content:
           application/json;charset=UTF-8:
@@ -515,6 +539,30 @@ paths:
           required: false
           schema:
             type: string
+        - name: Vipps-System-Name
+          in: header
+          description: The name of the ecommerce solution
+          schema:
+            type: string
+          example: woocommerce
+        - name: Vipps-System-Version
+          in: header
+          description: The version number of the ecommerce solution
+          schema:
+            type: string
+          example: "5.4"
+        - name: Vipps-System-Plugin-Name
+          in: header
+          description: The name of the ecommerce plugin
+          schema:
+            type: string
+          example: "vipps-woocommerce"
+        - name: Vipps-System-Plugin-Version
+          in: header
+          description: The version number of the ecommerce plugin
+          schema:
+            type: string
+          example: "1.2.1"
       requestBody:
         $ref: '#/components/requestBodies/PaymentActionsRequest'
       responses:
@@ -628,6 +676,30 @@ paths:
           required: false
           schema:
             type: string
+        - name: Vipps-System-Name
+          in: header
+          description: The name of the ecommerce solution
+          schema:
+            type: string
+          example: woocommerce
+        - name: Vipps-System-Version
+          in: header
+          description: The version number of the ecommerce solution
+          schema:
+            type: string
+          example: "5.4"
+        - name: Vipps-System-Plugin-Name
+          in: header
+          description: The name of the ecommerce plugin
+          schema:
+            type: string
+          example: "vipps-woocommerce"
+        - name: Vipps-System-Plugin-Version
+          in: header
+          description: The version number of the ecommerce plugin
+          schema:
+            type: string
+          example: "1.2.1"
       requestBody:
         content:
           application/json;charset=UTF-8:
@@ -758,6 +830,30 @@ paths:
           required: false
           schema:
             type: string
+        - name: Vipps-System-Name
+          in: header
+          description: The name of the ecommerce solution
+          schema:
+            type: string
+          example: woocommerce
+        - name: Vipps-System-Version
+          in: header
+          description: The version number of the ecommerce solution
+          schema:
+            type: string
+          example: "5.4"
+        - name: Vipps-System-Plugin-Name
+          in: header
+          description: The name of the ecommerce plugin
+          schema:
+            type: string
+          example: "vipps-woocommerce"
+        - name: Vipps-System-Plugin-Version
+          in: header
+          description: The version number of the ecommerce plugin
+          schema:
+            type: string
+          example: "1.2.1"
       requestBody:
         $ref: '#/components/requestBodies/PaymentActionsRequest'
       responses:
@@ -869,6 +965,30 @@ paths:
             characters.
           schema:
             type: string
+        - name: Vipps-System-Name
+          in: header
+          description: The name of the ecommerce solution
+          schema:
+            type: string
+          example: woocommerce
+        - name: Vipps-System-Version
+          in: header
+          description: The version number of the ecommerce solution
+          schema:
+            type: string
+          example: "5.4"
+        - name: Vipps-System-Plugin-Name
+          in: header
+          description: The name of the ecommerce plugin
+          schema:
+            type: string
+          example: "vipps-woocommerce"
+        - name: Vipps-System-Plugin-Version
+          in: header
+          description: The version number of the ecommerce plugin
+          schema:
+            type: string
+          example: "1.2.1"
       requestBody:
         $ref: '#/components/requestBodies/ForceApproveRequest'
       responses:
@@ -969,6 +1089,30 @@ paths:
           required: false
           schema:
             type: string
+        - name: Vipps-System-Name
+          in: header
+          description: The name of the ecommerce solution
+          schema:
+            type: string
+          example: woocommerce
+        - name: Vipps-System-Version
+          in: header
+          description: The version number of the ecommerce solution
+          schema:
+            type: string
+          example: "5.4"
+        - name: Vipps-System-Plugin-Name
+          in: header
+          description: The name of the ecommerce plugin
+          schema:
+            type: string
+          example: "vipps-woocommerce"
+        - name: Vipps-System-Plugin-Version
+          in: header
+          description: The version number of the ecommerce plugin
+          schema:
+            type: string
+          example: "1.2.1"
       responses:
         '200':
           description: Get payment Details

--- a/vipps-ecom-api.md
+++ b/vipps-ecom-api.md
@@ -2,7 +2,7 @@
 
 API version: 2.0
 
-Document version 2.0.13.
+Document version 2.1.0.
 
 See: Vipps eCom API [GitHub repository](https://github.com/vippsas/vipps-ecom-api),
 with
@@ -17,6 +17,7 @@ See also: [How it works](vipps-ecom-api-howitworks.md).
 ## Table of contents
 - [Flow diagram](#flow-diagram)
 - [API endpoints](#api-endpoints)
+- [Optional Vipps HTTP headers](#optional-vipps-http-headers)
 - [Initiate](#initiate)
   - [Regular eCommerce payments](#regular-ecommerce-payments)
   - [Express checkout payments](#express-checkout-payments)
@@ -114,6 +115,23 @@ Payments are supported in both web browsers and in native apps (via deep-linking
 
 See the
 [eCom API checklist](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api-checklist.md).
+
+## Optional Vipps HTTP headers
+
+We recommend using following _optional_ HTTP headers for all reaquests to the
+Vipps eCom API. The headers provide metadata about the merchant's system,
+which help Vipps improve our services.
+
+| Header                        | Description                           | Example value        |
+| ----------------------------- | ------------------------------------- | -------------------- |
+| `Vipps-System-Name`           | The name of the ecommerce solution    | `woocommerce`        |
+| `Vipps-System-Version`        | The version of the ecommerce solution | `5.4`                |
+| `Vipps-System-Plugin-Name`    | The name of the plugin                | `vipps-woocommerce`  |
+| `Vipps-System-Plugin-Version` | The version of the plugin             | `1.4.1`              |
+
+These headers are sent by the recent versions of
+[the official Vipps plugins](https://github.com/vippsas/vipps-developers#plugins)
+and we recommend all customers with direct integration with the API to also do so.
 
 ## Initiate
 

--- a/vipps-ecom-api.md
+++ b/vipps-ecom-api.md
@@ -122,12 +122,12 @@ We recommend using following _optional_ HTTP headers for all reaquests to the
 Vipps eCom API. The headers provide metadata about the merchant's system,
 which help Vipps improve our services.
 
-| Header                        | Description                           | Example value        |
-| ----------------------------- | ------------------------------------- | -------------------- |
-| `Vipps-System-Name`           | The name of the ecommerce solution    | `woocommerce`        |
-| `Vipps-System-Version`        | The version of the ecommerce solution | `5.4`                |
-| `Vipps-System-Plugin-Name`    | The name of the plugin                | `vipps-woocommerce`  |
-| `Vipps-System-Plugin-Version` | The version of the plugin             | `1.4.1`              |
+| Header                        | Description                                  | Example value        |
+| ----------------------------- | -------------------------------------------- | -------------------- |
+| `Vipps-System-Name`           | The name of the ecommerce solution           | `woocommerce`        |
+| `Vipps-System-Version`        | The version number of the ecommerce solution | `5.4`                |
+| `Vipps-System-Plugin-Name`    | The name of the plugin                       | `vipps-woocommerce`  |
+| `Vipps-System-Plugin-Version` | The version number of the plugin             | `1.4.1`              |
 
 These headers are sent by the recent versions of
 [the official Vipps plugins](https://github.com/vippsas/vipps-developers#plugins)

--- a/vipps-ecom-api.md
+++ b/vipps-ecom-api.md
@@ -2,7 +2,7 @@
 
 API version: 2.0
 
-Document version 2.1.0.
+Document version 2.1.1.
 
 See: Vipps eCom API [GitHub repository](https://github.com/vippsas/vipps-ecom-api),
 with
@@ -1127,9 +1127,9 @@ Request:
 
 ```http
 POST https://apitest.vipps.no/accessToken/get
-client_id: <client_id>
-client_secret: <client_secret>
-Ocp-Apim-Subscription-Key: <Ocp-Apim-Subscription-Key>
+client_id: fb492b5e-7907-4d83-ba20-c7fb60ca35de
+client_secret: Y8Kteew6GE2ZmeycEt6egg==
+Ocp-Apim-Subscription-Key: 0f14ebcab0ec4b29ae0cb90d91b4a84a
 ```
 
 (We are aware that this is a `POST`, without a body, to an endpoint with

--- a/vipps-ecom-api.md
+++ b/vipps-ecom-api.md
@@ -126,8 +126,8 @@ which help Vipps improve our services.
 | ----------------------------- | -------------------------------------------- | -------------------- |
 | `Vipps-System-Name`           | The name of the ecommerce solution           | `woocommerce`        |
 | `Vipps-System-Version`        | The version number of the ecommerce solution | `5.4`                |
-| `Vipps-System-Plugin-Name`    | The name of the plugin                       | `vipps-woocommerce`  |
-| `Vipps-System-Plugin-Version` | The version number of the plugin             | `1.4.1`              |
+| `Vipps-System-Plugin-Name`    | The name of the ecommerce plugin             | `vipps-woocommerce`  |
+| `Vipps-System-Plugin-Version` | The version number of the ecommerce plugin   | `1.4.1`              |
 
 These headers are sent by the recent versions of
 [the official Vipps plugins](https://github.com/vippsas/vipps-developers#plugins)

--- a/vipps-ecom-api.md
+++ b/vipps-ecom-api.md
@@ -118,9 +118,9 @@ See the
 
 ## Optional Vipps HTTP headers
 
-We recommend using following _optional_ HTTP headers for all reaquests to the
-Vipps eCom API. The headers provide metadata about the merchant's system,
-which help Vipps improve our services.
+We recommend using the following _optional_ HTTP headers for all requests to the
+Vipps eCom API. These headers provide useful metadata about the merchant's system,
+which help Vipps improve our services, and also help in investigating problems.
 
 | Header                        | Description                                  | Example value        |
 | ----------------------------- | -------------------------------------------- | -------------------- |
@@ -135,7 +135,7 @@ and we recommend all customers with direct integration with the API to also do s
 
 ## Initiate
 
-Vipps eCommerce API offers 2 types of payments:
+Vipps eCommerce API offers two types of payments:
 1. Regular eCommerce payments
 2. Express checkout payments
 

--- a/vipps-ecom-api.md
+++ b/vipps-ecom-api.md
@@ -2,7 +2,7 @@
 
 API version: 2.0
 
-Document version 2.1.1.
+Document version 2.1.2.
 
 See: Vipps eCom API [GitHub repository](https://github.com/vippsas/vipps-ecom-api),
 with
@@ -343,7 +343,7 @@ Example: Response body for `"isApp":false`, to the landing page:
 ```json
 {
     "orderId": "order123abc",
-    "url": "https://api.vipps.no/deeplink/vippsgateway?token=eyJraWQiOiJqd3R <snip>"
+    "url": "https://apitest.vipps.no/dwo-api-application/v1/deeplink/vippsgateway?v=2&token=eyJraWQiOiJqd3RrZXkiLC <snip>"
 }
 ```
 Example: Response body for `"isApp":true`, with a deeplink for app-switch:
@@ -351,11 +351,11 @@ Example: Response body for `"isApp":true`, with a deeplink for app-switch:
 ```json
 {
     "orderId": "order123abc",
-    "url": "vipps://?token=eyJraWQiOiJqd3RrZXkiLCJhbGciOiJSUzI1NiJ9.eyJzdWIi <snip>"
+    "url": "vipps://?token=eyJraWQiOiJqd3RrZXkiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiO <snip>"
 }
 ```
 
-The `url` is slightly simplified, but the format is correct.
+The `url` is truncated, but the format is correct.
 
 ## Payment identification
 


### PR DESCRIPTION
Optional HTTP headers to help us improve the eCom API.

----

## Optional Vipps HTTP headers

We recommend using the following _optional_ HTTP headers for all requests to the
Vipps eCom API. These headers provide useful metadata about the merchant's system,
which help Vipps improve our services, and also help in investigating problems.

| Header                        | Description                                  | Example value        |
| ----------------------------- | -------------------------------------------- | -------------------- |
| `Vipps-System-Name`           | The name of the ecommerce solution           | `woocommerce`        |
| `Vipps-System-Version`        | The version number of the ecommerce solution | `5.4`                |
| `Vipps-System-Plugin-Name`    | The name of the ecommerce plugin             | `vipps-woocommerce`  |
| `Vipps-System-Plugin-Version` | The version number of the ecommerce plugin   | `1.4.1`              |

These headers are sent by the recent versions of
[the official Vipps plugins](https://github.com/vippsas/vipps-developers#plugins)
and we recommend all customers with direct integration with the API to also do so.