### PR TITLE
Update swaggers POST /ecomm/v2/payments/{orderId}/refund example responses

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1646,6 +1646,46 @@ components:
           description: Transaction text to be displayed in Vipps
           example: One pair of Vipps socks
           maxLength: 100
+    TransactionInfoRefund:
+      type: object
+      required:
+        - amount
+        - status
+        - timeStamp
+        - transactionId
+        - transactionText
+      properties:
+        amount:
+          type: number
+          format: double
+          description: 'Ordered amount in øre (1 NOK = 100 øre)'
+          example: 20000
+        status:
+          type: string
+          enum:
+            - Cancelled
+            - Captured
+            - Refund
+          example: Refund
+          description: >-
+            Status which gives the current state of the payment within Vipps.
+            See the [API
+            guide](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#responses-from-requests)
+            for more information.
+        timeStamp:
+          type: string
+          description: Timestamp in ISO-8601 representing when the order was performed.
+          example: '2018-12-12T11:18:38.246Z'
+        transactionId:
+          type: string
+          description: Vipps transaction id
+          pattern: '^\d{10}$'
+          example: '5001420062'
+        transactionText:
+          type: string
+          description: Transaction text to be displayed in Vipps
+          example: One pair of Vipps socks
+          maxLength: 100
     TransactionDetails:
       type: object
       properties:
@@ -1737,9 +1777,9 @@ components:
           pattern: '^[a-zA-Z0-9-]{1,50}$'
           maxLength: 50
         transaction:
-          $ref: '#/components/schemas/TransactionInfo'
+          $ref: '#/components/schemas/TransactionInfoRefund'
         transactionSummary:
-          $ref: '#/components/schemas/TransactionSummary'
+          $ref: '#/components/schemas/TransactionSummaryWithRefund'
     TransactionResponse:
       type: object
       required:
@@ -2299,6 +2339,39 @@ components:
           format: int32
           description: Total remaining amount to refund
           example: 20000
+        bankIdentificationNumber:
+          type: integer
+          format: int32
+          description: Bank Identification Number, first 6 digit of card number
+          example: 123456
+    TransactionSummaryWithRefund:
+      type: object
+      required:
+        - capturedAmount
+        - refundedAmount
+        - remainingAmountToCapture
+        - remainingAmountToRefund
+      properties:
+        capturedAmount:
+          type: integer
+          format: int32
+          description: Total amount captured
+          example: 20000
+        refundedAmount:
+          type: integer
+          format: int32
+          description: Total refunded amount of the order
+          example: 20000
+        remainingAmountToCapture:
+          type: integer
+          format: int32
+          description: Total remaining amount to capture
+          example: 0
+        remainingAmountToRefund:
+          type: integer
+          format: int32
+          description: Total remaining amount to refund
+          example: 0
         bankIdentificationNumber:
           type: integer
           format: int32


### PR DESCRIPTION
The example responses used in the swagger docs does not seem to reflect that a refund has been completed by Vipps. This is a small issue, however, it was a bit confusing as I didn't fully understand what the api was doing when reading the swagger docs. 

Wrong responses: https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/refundPaymentUsingPOST @  /ecomm/v2/payments/{orderId}/refund 

Correct responses: https://www.vipps.no/developers-documentation/ecom/documentation#refund

Should be: 
`{
  "orderId": "acme-shop-123-order123abc",
  "transaction": {
    "amount": 20000,
    "transactionText": "Refund of Vipps socks",
    "status": "Refund",
    "transactionId": "5600727726",
    "timeStamp": "2018-11-14T15:23:02.286"
  },
  "transactionSummary": {
    "capturedAmount": 20000,
    "remainingAmountToCapture": 0,
    "refundedAmount": 20000,
    "remainingAmountToRefund": 0
  }
}`