### PR TITLE
Cancelling partially captured

### DIFF
--- a/vipps-ecom-api-faq.md
+++ b/vipps-ecom-api-faq.md
@@ -5,7 +5,7 @@ See:
 * [Vipps Recurring API FAQ](https://github.com/vippsas/vipps-recurring-api/blob/master/vipps-recurring-api-faq.md)
 * [Getting Started](https://github.com/vippsas/vipps-developers/blob/master/vipps-getting-started.md)
 
-Document version 3.11.6.
+Document version 3.12.0.
 
 ### Table of contents
 
@@ -615,12 +615,18 @@ has therefore made a
 [partial capture](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#partial-capture)
 of 750 NOK, and need to refund the remaining 250 NOK.
 
-The short version: This is done automatically by the bank after a few days.
+* The short version: This is done automatically by the bank after a few days.
 See:
 [For how long is a payment reserved?](#for-how-long-is-a-payment-reserved).
 
-The long version: It's not possible to cancel the remaining reservation after a
-partial capture through Vipps.
+* The long version: It _is_ possible to cancel the remaining reservation after a
+partial capture through Vipps: Send a
+[`PUT:/ecomm/v2/payments/{orderId}/cancel`](https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/cancelPaymentRequestUsingPUT)
+request with `shouldReleaseRemainingFunds: true` in the body.
+The payment must be `RESERVED` for this to take effect.
+See:
+[Cancelling a partially captured order](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#cancelling-a-partially-captured-order).
+
 The partial capture (the 750 of the 1000 NOK in the example above)
 is normally confirmed in the bank after 3-10 days, but it sometimes takes even
 longer. When this is done, the bank will make the remaining (250 NOK) available

--- a/vipps-ecom-api.md
+++ b/vipps-ecom-api.md
@@ -22,7 +22,7 @@ with
 
 API version: 2.0.0.
 
-Document version 2.5.68.
+Document version 2.5.69.
 
 ## Table of contents
 
@@ -1277,15 +1277,15 @@ can not be cancelled as described above.
 
 ### Cancelling a partially captured order
 
-If you wish to cancel an order which you have partially captured send a 
+If you wish to cancel an order which you have partially captured: Send a
 [`PUT:/ecomm/v2/payments/{orderId}/cancel`](https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/cancelPaymentRequestUsingPUT)
-request with the following property added to the body `shouldReleaseRemainingFunds: true`.
+request with `shouldReleaseRemainingFunds: true` in the body.
 The payment must be `RESERVED` for this to take effect.
 
 If this value is not set it will default to `false`. When `shouldReleaseRemainingFunds` is set to `false`
 any request to cancel after a partial or full capture has been performed will be rejected.
 
-This is a useful and recommended feature as it releases any reserved balance back to the customer imidiately.
+This is a useful and recommended feature as it releases any reserved balance back to the customer immediately.
 
 Example Request:
 


### PR DESCRIPTION
Also documented in the FAQ.
Fixed typos/language - now the same in API guide, FAQ and newsletter.