### PR TITLE
Fix msn regex

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1828,7 +1828,7 @@ components:
           minLength: 5
           maxLength: 6
           example: '123456'
-          pattern: '^\d{5,6}$'
+          pattern: '^\d{5,}$'
     ShippingDetails:
       type: object
       required:
@@ -2046,7 +2046,7 @@ components:
           minLength: 5
           maxLength: 6
           example: '123456'
-          pattern: '^\d{5,6}$'
+          pattern: '^\d{5,}$'
         paymentType:
           type: string
           description: >-
@@ -2204,7 +2204,7 @@ components:
           minLength: 5
           maxLength: 6
           example: '123456'
-          pattern: '^\d{5,6}$'
+          pattern: '^\d{5,}$'
         orderId:
           type: string
           description: >-
@@ -2237,7 +2237,7 @@ components:
           minLength: 5
           maxLength: 6
           example: '123456'
-          pattern: '^\d{5,6}$'
+          pattern: '^\d{5,}$'
         orderId:
           type: string
           description: >-

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1828,7 +1828,7 @@ components:
           minLength: 5
           maxLength: 6
           example: '123456'
-          pattern: '^\d{5+}$'
+          pattern: '^\d{5,6}$'
     ShippingDetails:
       type: object
       required:
@@ -2046,7 +2046,7 @@ components:
           minLength: 5
           maxLength: 6
           example: '123456'
-          pattern: '^\d{5+}$'
+          pattern: '^\d{5,6}$'
         paymentType:
           type: string
           description: >-
@@ -2204,7 +2204,7 @@ components:
           minLength: 5
           maxLength: 6
           example: '123456'
-          pattern: '^\d{5+}$'
+          pattern: '^\d{5,6}$'
         orderId:
           type: string
           description: >-
@@ -2237,7 +2237,7 @@ components:
           minLength: 5
           maxLength: 6
           example: '123456'
-          pattern: '^\d{5+}$'
+          pattern: '^\d{5,6}$'
         orderId:
           type: string
           description: >-


### PR DESCRIPTION
Existing regex `^\d{5+}$` for MSNs is invalid. Update to `^\d{5,6}$` which matches 5 to 6 digits inclusive.