### PR TITLE
Update EcomV2 CancelTransaction Request

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1328,6 +1328,8 @@ components:
           maxLength: 100
     CancelTransaction:
       type: object
+      required:
+        - transactionText
       properties:
         transactionText:
           type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,7 +3,7 @@ info:
   description: |
     # Vipps eCommerce API
     Additional API documentation: https://github.com/vippsas/vipps-ecom-api/
-  version: 1.6.23
+  version: 1.6.24
   title: Vipps eCommerce API
 tags:
   - name: Authorization Service


### PR DESCRIPTION
There is validation inside DWO that checks the TransactionText when doing /cancel, which requires this property. This is not reflected in the spec