### PR TITLE
Update to userinfo section

### DIFF
--- a/docs/shins/index.html
+++ b/docs/shins/index.html
@@ -2727,7 +2727,7 @@ System.out.println(response.toString());
 <td>body</td>
 <td>string</td>
 <td>false</td>
-<td>The requested OIDC scope for use with userinfo</td>
+<td>The requested OIDC scope for use with userinfo, possible values are</td>
 </tr>
 <tr>
 <td>»» additionalData</td>
@@ -2780,6 +2780,17 @@ System.out.println(response.toString());
 </tr>
 </tbody>
 </table>
+<h4 id="detailed-descriptions">Detailed descriptions</h4>
+<p><strong>»» scope</strong>: The requested OIDC scope for use with userinfo, possible values are</p>
+<ul>
+<li>name</li>
+<li>address</li>
+<li>email</li>
+<li>phoneNumber</li>
+<li>birthDate</li>
+<li>nin</li>
+<li>accountNumbers</li>
+</ul>
 <h4 id="enumerated-values-2">Enumerated Values</h4>
 <table>
 <thead>
@@ -2804,34 +2815,6 @@ System.out.println(response.toString());
 <tr>
 <td>»»» isDefault</td>
 <td>N</td>
-</tr>
-<tr>
-<td>»» scope</td>
-<td>name</td>
-</tr>
-<tr>
-<td>»» scope</td>
-<td>address</td>
-</tr>
-<tr>
-<td>»» scope</td>
-<td>email</td>
-</tr>
-<tr>
-<td>»» scope</td>
-<td>phoneNumber</td>
-</tr>
-<tr>
-<td>»» scope</td>
-<td>birthDate</td>
-</tr>
-<tr>
-<td>»» scope</td>
-<td>nin</td>
-</tr>
-<tr>
-<td>»» scope</td>
-<td>accountNumbers</td>
 </tr>
 </tbody>
 </table>
@@ -8433,7 +8416,7 @@ System.out.println(response.toString());
 <td>string</td>
 <td>false</td>
 <td>none</td>
-<td>The requested OIDC scope for use with userinfo</td>
+<td>The requested OIDC scope for use with userinfo, possible values are <br />- name<br />- address<br />- email<br />- phoneNumber<br />- birthDate<br />- nin<br />- accountNumbers</td>
 </tr>
 <tr>
 <td>additionalData</td>
@@ -8448,45 +8431,6 @@ System.out.println(response.toString());
 <td>false</td>
 <td>none</td>
 <td>Use the extended UX flow for express checkout which forces users to confirm their address and shipping choices</td>
-</tr>
-</tbody>
-</table>
-<h4 id="enumerated-values-22">Enumerated Values</h4>
-<table>
-<thead>
-<tr>
-<th>Property</th>
-<th>Value</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>scope</td>
-<td>name</td>
-</tr>
-<tr>
-<td>scope</td>
-<td>address</td>
-</tr>
-<tr>
-<td>scope</td>
-<td>email</td>
-</tr>
-<tr>
-<td>scope</td>
-<td>phoneNumber</td>
-</tr>
-<tr>
-<td>scope</td>
-<td>birthDate</td>
-</tr>
-<tr>
-<td>scope</td>
-<td>nin</td>
-</tr>
-<tr>
-<td>scope</td>
-<td>accountNumbers</td>
 </tr>
 </tbody>
 </table>
@@ -8658,7 +8602,7 @@ System.out.println(response.toString());
 </tr>
 </tbody>
 </table>
-<h4 id="enumerated-values-23">Enumerated Values</h4>
+<h4 id="enumerated-values-22">Enumerated Values</h4>
 <table>
 <thead>
 <tr>
@@ -8839,7 +8783,7 @@ System.out.println(response.toString());
 </tr>
 </tbody>
 </table>
-<h4 id="enumerated-values-24">Enumerated Values</h4>
+<h4 id="enumerated-values-23">Enumerated Values</h4>
 <table>
 <thead>
 <tr>
@@ -9631,7 +9575,7 @@ System.out.println(response.toString());
 </tr>
 </tbody>
 </table>
-<h4 id="enumerated-values-25">Enumerated Values</h4>
+<h4 id="enumerated-values-24">Enumerated Values</h4>
 <table>
 <thead>
 <tr>

--- a/docs/shins/index.html
+++ b/docs/shins/index.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8">
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <title>Vipps eCommerce API v1.6.26</title>
+    <title>Vipps eCommerce API v1.6.27</title>
 
     <style>
     </style>
@@ -2267,9 +2267,9 @@ curl -X POST https://apitest.vipps.no/ecomm/v2/payments \
   },
   &quot;merchantInfo&quot;: {
     &quot;authToken&quot;: &quot;iOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6ImllX3FXQ1hoWHh0MXpJ&quot;,
-    &quot;callbackPrefix&quot;: &quot;https://example.com/vipps/callbacks-for-payment-updates&quot;,
+    &quot;callbackPrefix&quot;: &quot;https://example.com/vipps/callbacks-for-payment-update-from-vipps&quot;,
     &quot;consentRemovalPrefix&quot;: &quot;https://example.com/vipps/consent-removal&quot;,
-    &quot;fallBack&quot;: &quot;https://example.com/vipps/fallback-order-result-page/acme-shop-123-order123abc&quot;,
+    &quot;fallBack&quot;: &quot;https://example.com/vipps/fallback-result-page-for-both-success-and-failure/acme-shop-123-order123abc&quot;,
     &quot;isApp&quot;: false,
     &quot;merchantSerialNumber&quot;: &quot;123456&quot;,
     &quot;paymentType&quot;: &quot;eComm Regular Payment&quot;,
@@ -2459,9 +2459,9 @@ System.out.println(response.toString());
   },
   <span class="hljs-attr">&quot;merchantInfo&quot;</span>: {
     <span class="hljs-attr">&quot;authToken&quot;</span>: <span class="hljs-string">&quot;iOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6ImllX3FXQ1hoWHh0MXpJ&quot;</span>,
-    <span class="hljs-attr">&quot;callbackPrefix&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/callbacks-for-payment-updates&quot;</span>,
+    <span class="hljs-attr">&quot;callbackPrefix&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/callbacks-for-payment-update-from-vipps&quot;</span>,
     <span class="hljs-attr">&quot;consentRemovalPrefix&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/consent-removal&quot;</span>,
-    <span class="hljs-attr">&quot;fallBack&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/fallback-order-result-page/acme-shop-123-order123abc&quot;</span>,
+    <span class="hljs-attr">&quot;fallBack&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/fallback-result-page-for-both-success-and-failure/acme-shop-123-order123abc&quot;</span>,
     <span class="hljs-attr">&quot;isApp&quot;</span>: <span class="hljs-literal">false</span>,
     <span class="hljs-attr">&quot;merchantSerialNumber&quot;</span>: <span class="hljs-string">&quot;123456&quot;</span>,
     <span class="hljs-attr">&quot;paymentType&quot;</span>: <span class="hljs-string">&quot;eComm Regular Payment&quot;</span>,
@@ -2615,7 +2615,7 @@ System.out.println(response.toString());
 <td>body</td>
 <td>string</td>
 <td>true</td>
-<td>Vipps will use the fallBack URL to redirect the Vipps user to the merchant’s confirmation page once the payment is completed in Vipps. This is normally the “success page”, although the “fallback” name is ambiguous (the same URL is also used if payment was not successful). In other words: This is the URL Vipps sends the Vipps user back to. URLs passed to Vipps must validate, see <a href="https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#url-validation">URL validation</a>. The URL must use HTTPS, or a custom URL scheme like &quot;myapp://&quot;&quot;.</td>
+<td>Vipps will use the fallBack URL to redirect the Vipps user to the merchant’s confirmation page once the payment is completed in Vipps. This is normally the “success page”, although the “fallback” name is ambiguous (the same URL is also used if payment was not successful). In other words: This is the URL Vipps sends the Vipps user back to. The page must handle both successful payments and payment failures. URLs passed to Vipps must validate, see <a href="https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#url-validation">URL validation</a>. The URL must use HTTPS, or a custom URL scheme like &quot;myapp://&quot;&quot;.</td>
 </tr>
 <tr>
 <td>»» isApp</td>
@@ -8296,9 +8296,9 @@ System.out.println(response.toString());
   },
   <span class="hljs-attr">&quot;merchantInfo&quot;</span>: {
     <span class="hljs-attr">&quot;authToken&quot;</span>: <span class="hljs-string">&quot;iOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6ImllX3FXQ1hoWHh0MXpJ&quot;</span>,
-    <span class="hljs-attr">&quot;callbackPrefix&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/callbacks-for-payment-updates&quot;</span>,
+    <span class="hljs-attr">&quot;callbackPrefix&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/callbacks-for-payment-update-from-vipps&quot;</span>,
     <span class="hljs-attr">&quot;consentRemovalPrefix&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/consent-removal&quot;</span>,
-    <span class="hljs-attr">&quot;fallBack&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/fallback-order-result-page/acme-shop-123-order123abc&quot;</span>,
+    <span class="hljs-attr">&quot;fallBack&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/fallback-result-page-for-both-success-and-failure/acme-shop-123-order123abc&quot;</span>,
     <span class="hljs-attr">&quot;isApp&quot;</span>: <span class="hljs-literal">false</span>,
     <span class="hljs-attr">&quot;merchantSerialNumber&quot;</span>: <span class="hljs-string">&quot;123456&quot;</span>,
     <span class="hljs-attr">&quot;paymentType&quot;</span>: <span class="hljs-string">&quot;eComm Regular Payment&quot;</span>,
@@ -8561,9 +8561,9 @@ System.out.println(response.toString());
 <a id="tocsmerchantinfo"></a></p>
 <pre class="highlight tab tab-json"><code>{
   <span class="hljs-attr">&quot;authToken&quot;</span>: <span class="hljs-string">&quot;iOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6ImllX3FXQ1hoWHh0MXpJ&quot;</span>,
-  <span class="hljs-attr">&quot;callbackPrefix&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/callbacks-for-payment-updates&quot;</span>,
+  <span class="hljs-attr">&quot;callbackPrefix&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/callbacks-for-payment-update-from-vipps&quot;</span>,
   <span class="hljs-attr">&quot;consentRemovalPrefix&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/consent-removal&quot;</span>,
-  <span class="hljs-attr">&quot;fallBack&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/fallback-order-result-page/acme-shop-123-order123abc&quot;</span>,
+  <span class="hljs-attr">&quot;fallBack&quot;</span>: <span class="hljs-string">&quot;https://example.com/vipps/fallback-result-page-for-both-success-and-failure/acme-shop-123-order123abc&quot;</span>,
   <span class="hljs-attr">&quot;isApp&quot;</span>: <span class="hljs-literal">false</span>,
   <span class="hljs-attr">&quot;merchantSerialNumber&quot;</span>: <span class="hljs-string">&quot;123456&quot;</span>,
   <span class="hljs-attr">&quot;paymentType&quot;</span>: <span class="hljs-string">&quot;eComm Regular Payment&quot;</span>,
@@ -8619,7 +8619,7 @@ System.out.println(response.toString());
 <td>string</td>
 <td>true</td>
 <td>none</td>
-<td>Vipps will use the fallBack URL to redirect the Vipps user to the merchant’s confirmation page once the payment is completed in Vipps. This is normally the “success page”, although the “fallback” name is ambiguous (the same URL is also used if payment was not successful). In other words: This is the URL Vipps sends the Vipps user back to. URLs passed to Vipps must validate, see <a href="https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#url-validation">URL validation</a>. The URL must use HTTPS, or a custom URL scheme like &quot;myapp://&quot;&quot;.</td>
+<td>Vipps will use the fallBack URL to redirect the Vipps user to the merchant’s confirmation page once the payment is completed in Vipps. This is normally the “success page”, although the “fallback” name is ambiguous (the same URL is also used if payment was not successful). In other words: This is the URL Vipps sends the Vipps user back to. The page must handle both successful payments and payment failures. URLs passed to Vipps must validate, see <a href="https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#url-validation">URL validation</a>. The URL must use HTTPS, or a custom URL scheme like &quot;myapp://&quot;&quot;.</td>
 </tr>
 <tr>
 <td>isApp</td>

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1930,9 +1930,8 @@ components:
           description: Skips the landing page for whitelisted sale units. Requires a valid customerInfo.mobileNumber.
         scope:
           type: string
-          description: The requested OIDC scope for use with userinfo
-          example: 'name address email'
-          enum:
+          description: |
+            The requested OIDC scope for use with userinfo, possible values are 
             - name
             - address
             - email
@@ -1940,6 +1939,7 @@ components:
             - birthDate
             - nin
             - accountNumbers
+          example: 'name address email'
         additionalData:
           $ref: '#/components/schemas/AdditionalTransactionData'
         useExplicitCheckoutFlow:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1098,10 +1098,8 @@ paths:
         - in: header
           name: Authorization
           description: >-
-            The access token is a base64-encoded string that is required for all API calls.
-            It is a JWT (JSON Web Token).
-            The access token is fetched from the `POST:/accesstoken/get` endpoint.
-            It is valid for 1 hour in the test environment and 24 hours in the production environment.
+            The access token is required to authorize the userinfo request. It should be sent as a Bearer token. 
+            The access token is received on a successful request to the token endpoint `POST:/oauth2/token` from the Vipps Login API.
           required: true
           schema:
             type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,7 +3,7 @@ info:
   description: |
     # Vipps eCommerce API
     Additional API documentation: https://github.com/vippsas/vipps-ecom-api/
-  version: 1.6.26
+  version: 1.6.27
   title: Vipps eCommerce API
 tags:
   - name: Authorization Service
@@ -2022,7 +2022,7 @@ components:
             We don't send requests to all ports, so to be safe use common ports such as: 80, 443, 8080.
             The URL must use HTTPS.
           maxLength: 255
-          example: 'https://example.com/vipps/callbacks-for-payment-updates'
+          example: 'https://example.com/vipps/callbacks-for-payment-update-from-vipps'
         consentRemovalPrefix:
           type: string
           description: >-
@@ -2045,11 +2045,12 @@ components:
             This is normally the “success page”, although the “fallback” name
             is ambiguous (the same URL is also used if payment was not successful).
             In other words: This is the URL Vipps sends the Vipps user back to.
+            The page must handle both successful payments and payment failures.
             URLs passed to Vipps must validate, see
             [URL validation](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#url-validation).
             The URL must use HTTPS, or a custom URL scheme like "myapp://"".
           maxLength: 255
-          example: 'https://example.com/vipps/fallback-order-result-page/acme-shop-123-order123abc'
+          example: 'https://example.com/vipps/fallback-result-page-for-both-success-and-failure/acme-shop-123-order123abc'
         isApp:
           type: boolean
           example: false

--- a/tools/vipps-ecom-api-postman-collection.json
+++ b/tools/vipps-ecom-api-postman-collection.json
@@ -46,11 +46,6 @@
 								"type": "text"
 							},
 							{
-								"key": "Ocp-Apim-Subscription-Key",
-								"value": "{{Ocp-Apim-Subscription-Key}}",
-								"type": "default"
-							},
-							{
 								"key": "Merchant-Serial-Number",
 								"value": "{{merchantSerialNumber}}",
 								"type": "default"
@@ -110,11 +105,6 @@
 								"key": "Authorization",
 								"type": "text",
 								"value": "Bearer {{login_token}}"
-							},
-							{
-								"key": "Ocp-Apim-Subscription-Key",
-								"value": "{{Ocp-Apim-Subscription-Key}}",
-								"type": "default"
 							},
 							{
 								"key": "Merchant-Serial-Number",

--- a/vipps-ecom-api-checklist.md
+++ b/vipps-ecom-api-checklist.md
@@ -2,7 +2,7 @@
 
 API version: 2.0.
 
-Document version 2.1.8.
+Document version 2.1.9.
 
 ## Checklist
 
@@ -36,7 +36,8 @@ Document version 2.1.8.
  - [ ] Avoid Integration pitfalls
     - [ ] The Merchant _must not_ rely on `fallback` or `callback` alone, and must poll
           [`GET:/ecomm/v2/payments/{orderId}/details`](https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/getPaymentDetailsUsingGET)
-          as documented (this is part of the first item in this checklist, but it's still a common error). Follow our [polling recommendations](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#polling-guidelines).  
+          as documented (this is part of the first item in this checklist, but it's still a common error).
+          Follow our [polling recommendations](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#polling-guidelines).  
     - [ ] The merchant must handle that the `fallback` URL is opened in the default browser on the phone,
           and not in a specific browser, in a specific tab, in an embedded browser, requiring a session token, etc.
           See the API guide:
@@ -59,7 +60,8 @@ Document version 2.1.8.
    BankID on
    [portal.vipps.no](https://portal.vipps.no)
    and retrieve API keys.
-4. The merchant completes all checklist items above. Please double check to avoid mistakes.
+4. The merchant completes all checklist items above.
+   Please double check to avoid mistakes.
 5. The merchant verifies the integration in the test environment by checking that
    there are test IDs (`orderId`) in the
    [Vipps test environment](https://github.com/vippsas/vipps-developers#the-vipps-test-environment-mt),

--- a/vipps-ecom-api-checklist.md
+++ b/vipps-ecom-api-checklist.md
@@ -2,7 +2,7 @@
 
 API version: 2.0.
 
-Document version 2.1.9.
+Document version 2.1.10.
 
 ## Checklist
 
@@ -14,7 +14,8 @@ Document version 2.1.9.
     - [ ] Details [`GET:/ecomm/v2/payments/{orderId}/details`](https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/getPaymentDetailsUsingGET)
     - For examples of requests and responses, see the Postman collection in [tools](tools/).
 - [ ] Send the [Vipps HTTP headers](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#vipps-http-headers)
-      in all API requests for better tracking and troubleshooting (mandatory for partners and platforms):
+      in all API requests for better tracking and troubleshooting
+      (mandatory for partners and platforms, who must send these headers as part of the checklist approval):
     - [ ] `Merchant-Serial-Number`    
     - [ ] `Vipps-System-Name`
     - [ ] `Vipps-System-Version`

--- a/vipps-ecom-api.md
+++ b/vipps-ecom-api.md
@@ -2188,10 +2188,6 @@ to retrieve all the information about the payment.
 | Merchant    | 21         | Reference orderId is not valid |
 | Merchant    | 22         | Reference orderId is not in valid state |
 | Merchant    | 97         | The merchant is not approved by Vipps to receive payments |
-|             | 121        | Agreement not found |
-|             | 122        | Agreement not active |
-|             | 123        | Connected payment source not active for Agreement |
-|             | 124        | No Network token available for this Agreement |
 
 ## Testing
 

--- a/vipps-ecom-api.md
+++ b/vipps-ecom-api.md
@@ -75,8 +75,8 @@ Document version 2.5.79.
   * [Polling guidelines](#polling-guidelines)
 * [Get payment status](#get-payment-status)
 * [Userinfo](#userinfo)
-  * [scope](#scope)
-  * [Userinfo call by call guide](#userinfo-call-by-call-guide)
+  * [Scope](#scope)
+  * [Userinfo call-by-call guide](#userinfo-call-by-call-guide)
   * [Get userinfo](#get-userinfo)
   * [Userinfo call](#userinfo-call)
   * [Consent](#consent)
@@ -188,8 +188,7 @@ All Vipps API calls are authenticated and authorized with an access token
 
 For more information about how to obtain an access token and all details around this, please see:
 [Quick overview of how to make an API call](https://github.com/vippsas/vipps-developers/blob/master/vipps-getting-started.md#quick-overview-of-how-to-make-an-api-call)
-in the
-[Getting started guide](https://github.com/vippsas/vipps-developers/blob/master/vipps-getting-started.md).
+in the Getting started guide.
 
 ## Vipps HTTP headers
 
@@ -1552,9 +1551,11 @@ Example of the userInfo flow:
 ![User info flow](images/userinfo-flow.png)
 
 
-### scope
+### Scope
 
-| scope            | Description | User consent required |
+Scope is the type of information you want access to. This can include any of the following values, separated by a space.
+
+| Scope            | Description | User consent required |
 | ---------------- | ----------- | --------------------- |
 | `address`        | A list containing the user's addresses. The list always contains the home address from the National Population Register and can also include work address and other addresses added by the user in Vipps. | yes |
 | `birthDate`      | Birth date. Verified with BankID. | yes |
@@ -1566,28 +1567,30 @@ Example of the userInfo flow:
 
 See the API specification for the formats and other details for each scope.
 
-**Please note:** If the e-mail address that is delivered has the flag `email_verified : false`
+**Please note:** If the e-mail address that is delivered has the flag `email_verified : false`,
 this address should not be used to link the user to an existing account without
 further authentication. Such authentication could be to prompt the user to
-login to the original account or confirm the account linking by having a
+log in to the original account or to confirm the account linking by providing a
 confirmation link sent to the email address.
 
-### Userinfo call by call guide
+### Userinfo call-by-call guide
 
 Scenario: You want to complete a payment and get the name and phone number of
-a customer.
+a customer. Details about each step are described in the sections below.
 
 1. Retrieve the access token:
-   [`POST:/accesstoken/get`](https://vippsas.github.io/vipps-recurring-api/#/Access%20Controller/getAccessToken).
-2. Add scope to the transaction object and include the scope you wish to get
-   access to (valid scope) before calling
-   [`POST:/ecomm/v2/payments`](https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/initiatePaymentV3UsingPOST)
-3. The user consents to the information sharing and perform the payment in Vipps.
-4. Retrieve the `sub` by calling
-   [`GET:/ecomm/v2/payments/{orderId}/details`](https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/getPaymentDetailsUsingGET)
-5. Using the sub from step 4, call
+   [`POST:/accesstoken/get`](https://vippsas.github.io/vipps-ecom-api/#/Authorization%20Service/fetchAuthorizationTokenUsingPost).
+2. Add `scope` to the
+   [`POST:/ecomm/v2/payments`](https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/initiatePaymentV3UsingPOST) call and include the scopes you need access to (e.g., "name address email phoneNumber birthDate"). Separate scopes with spaces.
+3. The user consents to sharing the information and performs the payment in Vipps.
+4. You retrieve the user identifier, `sub`, by calling
+   [`GET:/ecomm/v2/payments/{orderId}/details`](https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/getPaymentDetailsUsingGET).
+5. Retrieve a login token via the Vipps Login API:
+   [`POST:/access-management-1.0/access/oauth2/token`](https://vippsas.github.io/vipps-login-api/#/Vipps%20Login%20API/oauth2Token). Do not include the ``Ocp-Apim-Subscription-Key`` header or you will get an authorization error.
+6. Using the `sub` from step 4, call
    [`GET:/vipps-userinfo-api/userinfo/{sub}`](https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/getUserinfo)
    to retrieve the user's information.
+   Do not include the ``Ocp-Apim-Subscription-Key`` header. See more information under [Userinfo call](#userinfo-call).
 
 **Please note:** The `sub` is added asynchronously, so if the `/details` request
 is made within (milli)seconds of the payment approval in the app, it may not be
@@ -1604,7 +1607,7 @@ and will result in a `HTTP Unauthorized 401` error.
 
 ### Get userinfo
 
-Once the user completes the session a unique identifier `sub` can be retrieved from the
+Once the user completes the session, a unique identifier `sub` can be retrieved from the
 [`GET:/ecomm/v2/payments/{orderId}/details`](https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/getPaymentDetailsUsingGET) endpoint.
 
 Example `sub` format:
@@ -1621,20 +1624,31 @@ The `sub` is based on the user's national identity number ("fødselsnummer"
 in Norway), and does not change (except in very special cases).
 
 **Please note:** It is recommended to get the user's information directly after
-completing the transaction. There is however a _time limit of 168 hours_
-(one week) to retrieve the consented profile data from the `/userinfo` endpoint to
+completing the transaction. There is a _time limit of 168 hours_
+(one week) to retrieve the consented profile data from the `/userinfo` endpoint. This is to
 better support merchants that depend on manual steps/checks in their process of
 fetching the profile data. The merchant will get the information that is in the
 user profile at the time when they actually fetch the information. This means
 that the information might have changed from the time the user completed the
 transaction and the fetching of the profile data.
 
+
+### Userinfo authorization token
+
+For authorization, you need to get a new access token from the access-management path:
+[`POST:/access-management-1.0/access/oauth2/token`](https://vippsas.github.io/vipps-login-api/#/Vipps%20Login%20API/oauth2Token).
+Do not include the ``Ocp-Apim-Subscription-Key`` header or you will get an authorization error.
+
+**Important note:** Do not include any `OCP-APIM-Subscription-Key` key in the header. This is because the call is part of
+Vipps Login and is therefore _not_ under the same subscription as eComm. It will result in a `HTTP Unauthorized 401` error.
+
 ### Userinfo call
 
 This endpoint returns the payload with the information that the user has consented to share.
 
-Call [`GET:/vipps-userinfo-api/userinfo/{sub}`](https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/getUserinfo)
-with the `sub` that was retrieved earlier. See below on how to construct the call.
+The call is:
+[`GET:/vipps-userinfo-api/userinfo/{sub}`](https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/getUserinfo).
+Provide the `sub` that was retrieved earlier.
 
 **Request**
 
@@ -1642,14 +1656,14 @@ _Headers_
 
 | Header        | Description             |
 | ------------- | ----------------------- |
-| Authorization | "Bearer {Access Token}" |
+| Authorization | "Bearer {Login Token}"  |
 
-The access token is received on a successful request to the token endpoint described in [Authentication](#authentication).
+Authorization requires the new access token you got from
+[`POST:/access-management-1.0/access/oauth2/token`](https://vippsas.github.io/vipps-login-api/#/Vipps%20Login%20API/oauth2Token).
 
-**Important note:** `OCP-APIM-Subscription-Key` used for the eCom API must _not_ be included. This is because userinfo is part of
-Vipps Login and is therefore _not_ under the same subscription, and will result in a `HTTP Unauthorized 401` error.
+**Important note:** Do not include any `OCP-APIM-Subscription-Key` key in the header as it will result in a `HTTP Unauthorized 401` error.
 
-**Example response:**
+**Example response from a successful call:**
 
 ```json
 {
@@ -1699,31 +1713,34 @@ Vipps Login and is therefore _not_ under the same subscription, and will result 
 }
 ```
 
+Userinfo sequence:
+
 ![Userinfo sequence](images/userinfo-direct.png)
 
 ### Consent
 
 A user's consent to share information with a merchant applies across all Vipps
-services. Thus, if the merchant implements Vipps Login in addition to profile
-information as part of the payment flow, the merchant can also use Vipps to
+services. Thus, if the merchant implements Vipps Login as part of the payment flow,
+in addition to profile information, they can also use Vipps to
 log the user in without the need for additional consent.
 
 The user is presented with a consent card that must be accepted before
-approving the payment in Vipps. The following screens show examples
+approving the payment in Vipps. The following screenshots show examples
 of consent cards for Android(left) and iOS(right):
 
 ![Consent card](images/share-user-info.png)
 
 **Please note:** This operation has an "all or nothing" approach, so a user must
 complete a valid payment and consent to _all_ values in order to complete the
-session. If a user chooses to reject the terms the payment will not be
+session. If a user chooses to reject the terms, the payment will not be
 processed. Unless the whole flow is completed, this will be handled as a
 failed payment by the eCom API.
 
 ## HTTP response codes
 
 This API returns the following HTTP statuses in the responses.
-See the [API specification](https://github.com/vippsas/vipps-ecom-api).
+See the [API specification](https://github.com/vippsas/vipps-ecom-api) to find out which
+statuses returned for which endpoints.
 
 | HTTP status             | Description                                            |
 | ----------------------- | ------------------------------------------------------ |
@@ -1741,7 +1758,7 @@ See the [API specification](https://github.com/vippsas/vipps-ecom-api).
 HTTP responses with errors from the application gateway contain one error JSON object.
 Error responses produced from the application gateway include `401`, `403`, `422` and `429`.
 
-HTTP responses with errors from the Vipps backend will contain an _array_ of JSON objects.
+Note that the HTTP responses that contains errors from the Vipps backend will contain an _array_ of JSON objects.
 
 See [Errors](#errors) for more details.
 
@@ -1773,24 +1790,22 @@ is _far_ higher.
 
 ## Partner keys
 
-In addition to the normal [Authentication](#authentication) we offer _partner keys_,
+In addition to the normal [Authentication](#authentication), we offer _partner keys_
 which let a partner make API calls on behalf of a merchant.
 
-If you are a Vipps partner managing agreements on behalf of Vipps merchants you
+If you are a Vipps partner managing agreements on behalf of Vipps merchants, you
 can use your own API credentials to authenticate, and then send
 the `Merchant-Serial-Number` header to identify which of your merchants you
 are acting on behalf of. The `Merchant-Serial-Number` must be sent in the header
 of all API requests.
 
-By including the [Vipps HTTP Headers](#vipps-http-headers) you will make
+By including the [Vipps HTTP Headers](#vipps-http-headers), you will make
 it easier to investigate problems, if anything unexpected happens. Partners may
 re-use the values of the `Vipps-System-Name` and `Vipps-System-Plugin-Name` in
-the plugins headers if having different values do not make sense.
+the plugins headers, if having different values does not make sense.
 Note that the HTTP Headers are mandatory for partners and platforms.
 
-Here's an example of headers (please refer to the
-[API specification](https://vippsas.github.io/vipps-ecom-api/)
-for all the details):
+Here's an example of headers:
 
 ```http
 Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1Ni <snip>
@@ -1803,6 +1818,9 @@ Vipps-System-Plugin-Version: 4.5.6
 Content-Type: application/json
 ```
 
+Please refer to the
+[API specification](https://vippsas.github.io/vipps-ecom-api/) for all the details.
+
 **Please note:** The Merchant Serial Number (MSN) is a unique id for the sale
 unit. This is a required parameter if you are a Vipps partner making API requests
 on behalf of a merchant. The partner must use the _merchant's_ MSN, not the
@@ -1811,13 +1829,13 @@ merchants making API calls for themselves.
 
 ## Idempotency
 
-In a capture request the merchant may also use the `X-Request-Id` header.
-This header is an idempotency header ensuring that if the merchant retries
-a request with the same `X-Request-Id` the retried request will not make
+In a capture request, the merchant may also use the `X-Request-Id` header.
+This header is an idempotency header ensuring that, if the merchant retries
+a request with the same `X-Request-Id`, the retried request will not make
 additional changes.
 
 You can use any unique id for your `X-Request-Id`.
-See the API specification for details.
+See the [API specification](https://vippsas.github.io/vipps-ecom-api/) for details.
 
 Request:
 

--- a/vipps-ecom-api.md
+++ b/vipps-ecom-api.md
@@ -2188,6 +2188,10 @@ to retrieve all the information about the payment.
 | Merchant    | 21         | Reference orderId is not valid |
 | Merchant    | 22         | Reference orderId is not in valid state |
 | Merchant    | 97         | The merchant is not approved by Vipps to receive payments |
+|             | 121        | Agreement not found |
+|             | 122        | Agreement not active |
+|             | 123        | Connected payment source not active for Agreement |
+|             | 124        | No Network token available for this Agreement |
 
 ## Testing
 

--- a/vipps-ecom-api.md
+++ b/vipps-ecom-api.md
@@ -8,7 +8,7 @@ native apps and other solutions.
 
 API version: 2.0.0.
 
-Document version 2.5.78.
+Document version 2.5.79.
 
 ## Table of contents
 
@@ -477,8 +477,8 @@ A minimal example:
   "customerInfo": {},
   "merchantInfo": {
     "merchantSerialNumber": "123456",
-    "callbackPrefix": "https://example.com/vipps/callbacks-for-payment-update",
-    "fallBack": "https://example.com/vipps/fallback-result-page/acme-shop-123-order123abc"
+    "callbackPrefix": "https://example.com/vipps/callbacks-for-payment-update-from-vipps",
+    "fallBack": "https://example.com/vipps/fallback-result-page-for-both-success-and-failure/acme-shop-123-order123abc"
   },
   "transaction": {
     "orderId": "acme-shop-123-order123abc",
@@ -497,9 +497,9 @@ An express payment example with more parameters provided:
   },
   "merchantInfo": {
     "authToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1Ni <snip>",
-    "callbackPrefix": "https://example.com/vipps/callbacks-for-payment-update",
+    "callbackPrefix": "https://example.com/vipps/callbacks-for-payment-update-from-vipps",
     "consentRemovalPrefix": "https://example.com/vipps/consents/",
-    "fallBack": "https://example.com/vipps/fallback-result-page/acme-shop-123-order123abc",
+    "fallBack": "https://example.com/vipps/fallback-result-page-for-both-success-and-failure/acme-shop-123-order123abc",
     "merchantSerialNumber": 123456,
     "shippingDetailsPrefix": "https://example.com/vipps/shipping/",
     "paymentType": "eComm Express Payment",
@@ -707,7 +707,7 @@ It is, naturally, not possible to use `http://localhost` or
 Ngrok may also be an option: https://ngrok.com
 
 Here is a simple Java class suitable for testing URLs,
-using the dummy URL `https://example.com/vipps/fallback-result-page/acme-shop-123-order123abc`:
+using the dummy URL `https://example.com/vipps/fallback-result-page-for-both-success-and-failure/acme-shop-123-order123abc`:
 
 ```java
 import org.apache.commons.validator.routines.UrlValidator;
@@ -716,7 +716,7 @@ public class UrlValidate {
  public static void main(String[] args) {
   UrlValidator urlValidator = new UrlValidator();
 
-  if (urlValidator.isValid("https://example.com/vipps/fallback-result-page/acme-shop-123-order123abc")) {
+  if (urlValidator.isValid("https://example.com/vipps/fallback-result-page-for-both-success-and-failure/acme-shop-123-order123abc")) {
    System.out.println("URL is valid");
   } else {
    System.out.println("URL is invalid");
@@ -978,7 +978,7 @@ address), the parameter `staticShippingDetails` can be used in the initiate call
 Then, there is no need to implement
 [`POST:/v2/payments/{orderId}/shippingDetails`](https://vippsas.github.io/vipps-ecom-api/#/Endpoints_required_by_Vipps_from_the_merchant/fetchShippingCostUsingPOST).
 
-See 
+See
 [Initiate payment flow: API calls](#initiate-payment-flow-api-calls) for details.
 
 ### Get shipping details
@@ -1196,7 +1196,7 @@ there is a remaining reserved amount.
 
 If one or more partial captures have been made, any remaining reserved amount
 will be automatically released after a few days.
-See also the FAQ: 
+See also the FAQ:
 [For how long is a payment reserved](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api-faq.md#for-how-long-is-a-payment-reserved).
 
 It is not possible to refund the remaining amount since it has not been captured,


### PR DESCRIPTION
Most of this is superficial, but I had trouble following the instructions for getting the userinfo, so I added a bit more to that section.

In the yaml file, the description for the userinfo access token seemed to refer to the "regular access token", but it needs a token from the Login API instead. So I reused the description from the Login API access token section. 

I found out that you should NOT include the subscription key in the header for the userinfo and login calls, and I'd added those in to the postman, so I'm removing those here.