### PR TITLE
Remove the Ocp-Apim-Subscription-Key from the two login postman examples 

### DIFF
--- a/tools/vipps-ecom-api-postman-collection.json
+++ b/tools/vipps-ecom-api-postman-collection.json
@@ -46,11 +46,6 @@
 								"type": "text"
 							},
 							{
-								"key": "Ocp-Apim-Subscription-Key",
-								"value": "{{Ocp-Apim-Subscription-Key}}",
-								"type": "default"
-							},
-							{
 								"key": "Merchant-Serial-Number",
 								"value": "{{merchantSerialNumber}}",
 								"type": "default"
@@ -110,11 +105,6 @@
 								"key": "Authorization",
 								"type": "text",
 								"value": "Bearer {{login_token}}"
-							},
-							{
-								"key": "Ocp-Apim-Subscription-Key",
-								"value": "{{Ocp-Apim-Subscription-Key}}",
-								"type": "default"
 							},
 							{
 								"key": "Merchant-Serial-Number",


### PR DESCRIPTION
Do not include any `OCP-APIM-Subscription-Key` key in the header. This is because the call is part of
Vipps Login and is therefore _not_ under the same subscription as eCom. It will result in a `HTTP Unauthorized 401` error.