### PR TITLE
Amount clean-up

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1163,6 +1163,7 @@ components:
           $ref: '#/components/schemas/Address'
         shippingCost:
           type: integer
+          minimum: 0
           escription: 'Shipping cost. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.'
           example: 1500
         shippingMethod:
@@ -1458,6 +1459,7 @@ components:
       properties:
         amount:
           type: integer
+          minimum: 100
           description: 'Ordered amount. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.'
           example: 49900
         status:
@@ -1499,6 +1501,7 @@ components:
       properties:
         amount:
           type: integer
+          minimum: 100
           description:
             'Ordered amount in øre. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.'
           example: 49900
@@ -1639,6 +1642,7 @@ components:
           $ref: '#/components/schemas/AddressExpress'
         shippingCost:
           type: integer
+          minimum: 0
           description: 'Shipping cost, in øre. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.'
           example: 9900
         shippingMethod:
@@ -1766,6 +1770,7 @@ components:
           format: int32
         shippingCost:
           type: integer
+          minimum: 0
           description: 'Shipping cost. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.'
           example: 9900
         shippingMethod:
@@ -2048,6 +2053,7 @@ components:
         addressId:
           type: integer
           format: int32
+          minimum: 100
           description: >-
             Vipps Provided address Id. To be returned in response in the same
             field

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1188,7 +1188,6 @@ components:
       properties:
         amount:
           type: integer
-          format: int32
         operation:
           type: string
           example: RESERVE
@@ -1767,7 +1766,6 @@ components:
             - 'N'
         priority:
           type: integer
-          format: int32
         shippingCost:
           type: integer
           minimum: 0
@@ -1808,7 +1806,6 @@ components:
       properties:
         amount:
           type: integer
-          format: int32
           description: >-
             Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
@@ -2028,7 +2025,6 @@ components:
       properties:
         amount:
           type: integer
-          format: int32
           description: >-
             Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
@@ -2052,7 +2048,6 @@ components:
       properties:
         addressId:
           type: integer
-          format: int32
           minimum: 100
           description: >-
             Vipps Provided address Id. To be returned in response in the same
@@ -2241,7 +2236,6 @@ components:
       properties:
         addressId:
           type: integer
-          format: int32
         orderId:
           type: string
           description: >-
@@ -2265,27 +2259,22 @@ components:
       properties:
         capturedAmount:
           type: integer
-          format: int32
           description: Total amount captured
           example: 49900
         refundedAmount:
           type: integer
-          format: int32
           description: Total refunded amount of the order
           example: 0
         remainingAmountToCapture:
           type: integer
-          format: int32
           description: Total remaining amount to capture
           example: 0
         remainingAmountToRefund:
           type: integer
-          format: int32
           description: Total remaining amount to refund
           example: 49900
         bankIdentificationNumber:
           type: integer
-          format: int32
           description: Bank Identification Number, first 6 digit of card number
           example: 123456
     TransactionUpdateCallbackOneOf:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2,7 +2,7 @@ openapi: '3.0.0'
 info:
   description: |
     For details, see the [API Guide](https://vippsas.github.io/vipps-developer-docs/docs/APIs/ecom-api).
-  version: 1.6.37
+  version: 1.6.38
   title: Vipps eCommerce API
 tags:
   - name: Authorization Service
@@ -1162,9 +1162,8 @@ components:
         address:
           $ref: '#/components/schemas/Address'
         shippingCost:
-          type: number
-          format: double
-          description: Shipping Cost
+          type: integer
+          escription: 'Shipping cost. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.'
           example: 1500
         shippingMethod:
           type: string
@@ -1392,8 +1391,7 @@ components:
         - timeStamp
       properties:
         amount:
-          type: number
-          format: double
+          type: integer
           description:
             'Ordered amount. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.'
           example: 49900
@@ -1426,8 +1424,7 @@ components:
         - timeStamp
       properties:
         amount:
-          type: number
-          format: double
+          type: integer
           description: 'Ordered amount. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.'
           example: 49900
         status:
@@ -1460,8 +1457,7 @@ components:
         - timeStamp
       properties:
         amount:
-          type: number
-          format: double
+          type: integer
           description: 'Ordered amount. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.'
           example: 49900
         status:
@@ -1502,8 +1498,7 @@ components:
         - transactionText
       properties:
         amount:
-          type: number
-          format: double
+          type: integer
           description:
             'Ordered amount in øre. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.'
           example: 49900
@@ -1542,8 +1537,7 @@ components:
         - transactionText
       properties:
         amount:
-          type: number
-          format: double
+          type: integer
           description: >-
             Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
@@ -1644,8 +1638,7 @@ components:
         address:
           $ref: '#/components/schemas/AddressExpress'
         shippingCost:
-          type: number
-          format: double
+          type: integer
           description: 'Shipping cost, in øre. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.'
           example: 9900
         shippingMethod:
@@ -1772,8 +1765,8 @@ components:
           type: integer
           format: int32
         shippingCost:
-          type: number
-          format: double
+          type: integer
+          description: 'Shipping cost. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.'
           example: 9900
         shippingMethod:
           type: string


### PR DESCRIPTION
Background: https://vippsas.slack.com/archives/C8HP1AJ79/p1670088857709249

* Specific `integer`, not `number`
* Changed `double` to integer`
* Removed `format: int32`, as it's the default and we're nowhere near any limits anyway

See also: https://swagger.io/specification/

I also realised that `shippingCost` is in øre, not kroner (as everywhere else). See also the updated examples: https://github.com/vippsas/vipps-ecom-api/commit/98d22b9bbe68dfc944beac5f5511b48bd5825f59